### PR TITLE
FIX: exclude bots of inaccessible/unreachable mentions

### DIFF
--- a/plugins/chat/lib/chat/notifier.rb
+++ b/plugins/chat/lib/chat/notifier.rb
@@ -172,8 +172,8 @@ module Chat
 
       {
         members: members || [],
-        welcome_to_join: (welcome_to_join || []).select { |u| u.human? },
-        unreachable: (unreachable || []).select { |u| u.human? },
+        welcome_to_join: (welcome_to_join || []).select(&:human?),
+        unreachable: (unreachable || []).select(&:human?),
       }
     end
 

--- a/plugins/chat/lib/chat/notifier.rb
+++ b/plugins/chat/lib/chat/notifier.rb
@@ -104,8 +104,6 @@ module Chat
       to_notify
     end
 
-    private
-
     def list_users_to_notify
       skip_notifications = @parsed_mentions.count > SiteSetting.max_mentions_per_chat_message
 
@@ -126,6 +124,8 @@ module Chat
 
       [to_notify, inaccessible, all_mentioned_user_ids]
     end
+
+    private
 
     def expand_global_mention(to_notify, already_covered_ids)
       has_all_mention = @parsed_mentions.has_global_mention
@@ -187,6 +187,7 @@ module Chat
             .not_suspended
             .where.not(username_lower: @user.username_lower)
             .where.not(id: already_covered_ids)
+            .human_users
       end
 
       grouped = group_users_to_notify(direct_mentions)

--- a/plugins/chat/lib/chat/notifier.rb
+++ b/plugins/chat/lib/chat/notifier.rb
@@ -172,8 +172,8 @@ module Chat
 
       {
         members: members || [],
-        welcome_to_join: welcome_to_join || [],
-        unreachable: unreachable || [],
+        welcome_to_join: (welcome_to_join || []).select { |u| u.human? },
+        unreachable: (unreachable || []).select { |u| u.human? },
       }
     end
 
@@ -187,7 +187,6 @@ module Chat
             .not_suspended
             .where.not(username_lower: @user.username_lower)
             .where.not(id: already_covered_ids)
-            .human_users
       end
 
       grouped = group_users_to_notify(direct_mentions)

--- a/plugins/chat/spec/lib/chat/notifier_spec.rb
+++ b/plugins/chat/spec/lib/chat/notifier_spec.rb
@@ -285,12 +285,15 @@ describe Chat::Notifier do
 
         expect(inaccessible[:welcome_to_join]).to be_empty
 
-        channel.add(bot)
+        msg =
+          build_cooked_msg(
+            "Hello @bot",
+            user_1,
+            chat_channel: Fabricate(:private_category_channel, group: Fabricate(:group)),
+          )
+        _, inaccessible, _ = described_class.new(msg, msg.created_at).list_users_to_notify
 
-        msg = build_cooked_msg("Hello @bot", user_1)
-        to_notify, _, _ = described_class.new(msg, msg.created_at).list_users_to_notify
-
-        expect(to_notify[:direct_mentions]).to be_empty
+        expect(inaccessible[:unreachable]).to be_empty
       end
 
       it "include users as direct mentions even if there's a @all mention" do

--- a/plugins/chat/spec/lib/chat/notifier_spec.rb
+++ b/plugins/chat/spec/lib/chat/notifier_spec.rb
@@ -277,7 +277,7 @@ describe Chat::Notifier do
         expect(to_notify[:direct_mentions]).to contain_exactly(user_2.id)
       end
 
-      it "doesn’t attempt to notify bots" do
+      it "doesn’t attempt to notify bots not in the channel" do
         bot = Fabricate(:user, username: "bot", id: -999)
 
         msg = build_cooked_msg("Hello @bot", user_1)

--- a/plugins/chat/spec/lib/chat/notifier_spec.rb
+++ b/plugins/chat/spec/lib/chat/notifier_spec.rb
@@ -277,6 +277,22 @@ describe Chat::Notifier do
         expect(to_notify[:direct_mentions]).to contain_exactly(user_2.id)
       end
 
+      it "doesn’t attempt to notify bots" do
+        bot = Fabricate(:user, username: "bot", id: -999)
+
+        msg = build_cooked_msg("Hello @bot", user_1)
+        _, inaccessible, _ = described_class.new(msg, msg.created_at).list_users_to_notify
+
+        expect(inaccessible[:welcome_to_join]).to be_empty
+
+        channel.add(bot)
+
+        msg = build_cooked_msg("Hello @bot", user_1)
+        to_notify, _, _ = described_class.new(msg, msg.created_at).list_users_to_notify
+
+        expect(to_notify[:direct_mentions]).to be_empty
+      end
+
       it "include users as direct mentions even if there's a @all mention" do
         msg = build_cooked_msg("Hello @all and @#{user_2.username}", user_1)
 


### PR DESCRIPTION
It will prevent to show a notice saying the bot is not part of the channel.